### PR TITLE
선생님 등록 조회 api 구현

### DIFF
--- a/app/api/admin/teacher/route.ts
+++ b/app/api/admin/teacher/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { CreateTeacherAuthUseCase } from '@/backend/admin/teacher/usecases/CreateTeacherAuthUseCase';
+import { SelectTeacherAuthListUseCase } from '@/backend/admin/teacher/usecases/SelectTeacherAuthListUseCase';
 import { PrAdmTchrAuthCreateRepository } from '@/backend/common/infrastructures/repositories/PrAdmTchrAuthCreateRepository';
 import prisma from '@/libs/prisma';
 
@@ -10,9 +11,7 @@ export async function POST(request: NextRequest) {
     const { teacherId, imgUrl } = requestBody;
 
     const teacherAuthRepository = new PrAdmTchrAuthCreateRepository(prisma);
-    const createTeacherAuthUseCase = new CreateTeacherAuthUseCase(
-      teacherAuthRepository
-    );
+    const createTeacherAuthUseCase = new CreateTeacherAuthUseCase(teacherAuthRepository);
 
     const teacherAuth = await createTeacherAuthUseCase.execute({
       teacherId,
@@ -36,5 +35,33 @@ export async function POST(request: NextRequest) {
     const errorMessage =
       error instanceof Error ? error.message : '서버 오류가 발생했습니다.';
     return NextResponse.json({ error: errorMessage }, { status: 400 });
+  }
+}
+
+// 교사 인증 요청 목록 조회
+export async function GET() {
+  try {
+    const teacherAuthRepository = new PrAdmTchrAuthCreateRepository(prisma);
+    const selectTeacherAuthUseCase = new SelectTeacherAuthListUseCase(teacherAuthRepository);
+
+    const result = await selectTeacherAuthUseCase.getAllTeacherAuths();
+
+    return NextResponse.json({
+      message: '교사 인증 요청 목록 조회가 완료되었습니다.',
+      data: {
+        teacherAuths: result.teacherAuths.map((auth) => ({
+          id: auth.id,
+          teacherId: auth.teacherId,
+          imgUrl: auth.imgUrl,
+          createdAt: auth.createdAt,
+        })),
+        total: result.total,
+      },
+    });
+  } catch (error) {
+    console.error('Teacher auth list error:', error);
+    const errorMessage =
+      error instanceof Error ? error.message : '서버 오류가 발생했습니다.';
+    return NextResponse.json({ error: errorMessage }, { status: 500 });
   }
 }

--- a/backend/admin/teacher/usecases/SelectTeacherAuthListUseCase.ts
+++ b/backend/admin/teacher/usecases/SelectTeacherAuthListUseCase.ts
@@ -1,0 +1,24 @@
+import { TeacherAuthorization } from '@/backend/common/domains/entities/TeacherAuthorization';
+import { IAdmTchrAuthCreateRepository } from '@/backend/common/domains/repositories/IAdmTchrAuthCreateRepository';
+
+export class SelectTeacherAuthListUseCase {
+  private teacherAuthRepository: IAdmTchrAuthCreateRepository;
+
+  constructor(teacherAuthRepository: IAdmTchrAuthCreateRepository) {
+    this.teacherAuthRepository = teacherAuthRepository;
+  }
+
+  async getAllTeacherAuths(): Promise<{ teacherAuths: TeacherAuthorization[]; total: number }> {
+    try {
+      const teacherAuths = await this.teacherAuthRepository.findAll();
+
+      return {
+        teacherAuths,
+        total: teacherAuths.length,
+      };
+    } catch (error) {
+      console.error('교사 인증 요청 목록 조회 실패:', error);
+      throw new Error('교사 인증 요청 목록 조회 중 오류가 발생했습니다.');
+    }
+  }
+}

--- a/backend/common/domains/repositories/IAdmTchrAuthCreateRepository.ts
+++ b/backend/common/domains/repositories/IAdmTchrAuthCreateRepository.ts
@@ -2,4 +2,5 @@ import { TeacherAuthorization } from '../entities/TeacherAuthorization';
 
 export interface IAdmTchrAuthCreateRepository {
   create(teacherId: string, imgUrl: string): Promise<TeacherAuthorization>;
+  findAll(): Promise<TeacherAuthorization[]>;
 }

--- a/backend/common/infrastructures/repositories/PrAdmTchrAuthCreateRepository.ts
+++ b/backend/common/infrastructures/repositories/PrAdmTchrAuthCreateRepository.ts
@@ -67,4 +67,20 @@ export class PrAdmTchrAuthCreateRepository
       );
     }
   }
+
+  async findAll(): Promise<TeacherAuthorization[]> {
+    try {
+      const teacherAuths = await this.prisma.teacherAuthorization.findMany({
+        orderBy: {
+          createdAt: 'desc',
+        },
+      });
+
+      return teacherAuths.map(auth => this.mapToEntity(auth));
+    } catch (error) {
+      console.error('교사 인증 요청 목록 조회 실패', error);
+      throw new Error('교사 인증 요청 목록을 조회하는 중 오류가 발생했습니다.');
+    }
+  }
+
 }


### PR DESCRIPTION
## 🔥 PR 제목

선생님 등록 조회 api 구현

## ✨ 작업 내용

사용자는 학생 사용자에서 선생님 사용자로 변경을 위해 선생님 등록을 하게 되는데 그 등록 리스트를 조회하는 API 구현

## ✅ 체크리스트

- [ ] 코드가 정상적으로 동작하는지 확인했습니다.
- [ ] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [ ] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [ ] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.

## 🚀 테스트 방법
npm run dev 

PostMan에 HTTP GET 설정 후 
http://localhost:3000/api/admin/teacher URL 입력

## 📸 스크린샷 / 시연 (선택)
<img width="1367" height="711" alt="image" src="https://github.com/user-attachments/assets/911fae3c-061c-482e-b9fd-a4b6cc4f291a" />

생성 API에서 선생님 등록을 위해 선생님 등록 생성 했던 계정의 게시글을 볼 수 있음

## 🙏 리뷰어에게 한마디

수고하십시요~
