### PR TITLE
선생님 등록 삭제 API 구현

### DIFF
--- a/app/api/admin/teacher/route.ts
+++ b/app/api/admin/teacher/route.ts
@@ -12,7 +12,9 @@ export async function POST(request: NextRequest) {
     const { teacherId, imgUrl } = requestBody;
 
     const teacherAuthRepository = new PrAdmTchrAuthRepository(prisma);
-    const createTeacherAuthUseCase = new CreateTeacherAuthUseCase(teacherAuthRepository);
+    const createTeacherAuthUseCase = new CreateTeacherAuthUseCase(
+      teacherAuthRepository
+    );
 
     const teacherAuth = await createTeacherAuthUseCase.execute({
       teacherId,
@@ -43,7 +45,9 @@ export async function POST(request: NextRequest) {
 export async function GET() {
   try {
     const teacherAuthRepository = new PrAdmTchrAuthRepository(prisma);
-    const selectTeacherAuthUseCase = new SelectTeacherAuthListUseCase(teacherAuthRepository);
+    const selectTeacherAuthUseCase = new SelectTeacherAuthListUseCase(
+      teacherAuthRepository
+    );
 
     const result = await selectTeacherAuthUseCase.getAllTeacherAuths();
 
@@ -73,15 +77,17 @@ export async function DELETE(request: NextRequest) {
     const { id } = await request.json();
 
     const teacherAuthRepository = new PrAdmTchrAuthRepository(prisma);
-    const deleteTeacherAuthUseCase = new DeleteTeacherAuthUseCase(teacherAuthRepository);
+    const deleteTeacherAuthUseCase = new DeleteTeacherAuthUseCase(
+      teacherAuthRepository
+    );
 
     const deletedAuth = await deleteTeacherAuthUseCase.execute(id);
 
     return NextResponse.json({
       message: '교사 인증 요청이 성공적으로 삭제되었습니다.',
-      data: { 
-        id: deletedAuth.id, 
-        teacherId: deletedAuth.teacherId 
+      data: {
+        id: deletedAuth.id,
+        teacherId: deletedAuth.teacherId,
       },
     });
   } catch (error) {

--- a/app/api/admin/teacher/route.ts
+++ b/app/api/admin/teacher/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { CreateTeacherAuthUseCase } from '@/backend/admin/teacher/usecases/CreateTeacherAuthUseCase';
 import { SelectTeacherAuthListUseCase } from '@/backend/admin/teacher/usecases/SelectTeacherAuthListUseCase';
-import { PrAdmTchrAuthCreateRepository } from '@/backend/common/infrastructures/repositories/PrAdmTchrAuthCreateRepository';
+import { PrAdmTchrAuthRepository } from '@/backend/common/infrastructures/repositories/PrAdmTchrAuthRepository';
 import prisma from '@/libs/prisma';
 
 // 교사 인증 요청 생성
@@ -10,8 +10,10 @@ export async function POST(request: NextRequest) {
     const requestBody = await request.json();
     const { teacherId, imgUrl } = requestBody;
 
-    const teacherAuthRepository = new PrAdmTchrAuthCreateRepository(prisma);
-    const createTeacherAuthUseCase = new CreateTeacherAuthUseCase(teacherAuthRepository);
+    const teacherAuthRepository = new PrAdmTchrAuthRepository(prisma);
+    const createTeacherAuthUseCase = new CreateTeacherAuthUseCase(
+      teacherAuthRepository
+    );
 
     const teacherAuth = await createTeacherAuthUseCase.execute({
       teacherId,
@@ -41,8 +43,10 @@ export async function POST(request: NextRequest) {
 // 교사 인증 요청 목록 조회
 export async function GET() {
   try {
-    const teacherAuthRepository = new PrAdmTchrAuthCreateRepository(prisma);
-    const selectTeacherAuthUseCase = new SelectTeacherAuthListUseCase(teacherAuthRepository);
+    const teacherAuthRepository = new PrAdmTchrAuthRepository(prisma);
+    const selectTeacherAuthUseCase = new SelectTeacherAuthListUseCase(
+      teacherAuthRepository
+    );
 
     const result = await selectTeacherAuthUseCase.getAllTeacherAuths();
 

--- a/app/api/admin/teacher/route.ts
+++ b/app/api/admin/teacher/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { CreateTeacherAuthUseCase } from '@/backend/admin/teacher/usecases/CreateTeacherAuthUseCase';
 import { SelectTeacherAuthListUseCase } from '@/backend/admin/teacher/usecases/SelectTeacherAuthListUseCase';
+import { DeleteTeacherAuthUseCase } from '@/backend/admin/teacher/usecases/DeleteTeacherAuthUseCase';
 import { PrAdmTchrAuthRepository } from '@/backend/common/infrastructures/repositories/PrAdmTchrAuthRepository';
 import prisma from '@/libs/prisma';
 
@@ -11,9 +12,7 @@ export async function POST(request: NextRequest) {
     const { teacherId, imgUrl } = requestBody;
 
     const teacherAuthRepository = new PrAdmTchrAuthRepository(prisma);
-    const createTeacherAuthUseCase = new CreateTeacherAuthUseCase(
-      teacherAuthRepository
-    );
+    const createTeacherAuthUseCase = new CreateTeacherAuthUseCase(teacherAuthRepository);
 
     const teacherAuth = await createTeacherAuthUseCase.execute({
       teacherId,
@@ -44,9 +43,7 @@ export async function POST(request: NextRequest) {
 export async function GET() {
   try {
     const teacherAuthRepository = new PrAdmTchrAuthRepository(prisma);
-    const selectTeacherAuthUseCase = new SelectTeacherAuthListUseCase(
-      teacherAuthRepository
-    );
+    const selectTeacherAuthUseCase = new SelectTeacherAuthListUseCase(teacherAuthRepository);
 
     const result = await selectTeacherAuthUseCase.getAllTeacherAuths();
 
@@ -67,5 +64,30 @@ export async function GET() {
     const errorMessage =
       error instanceof Error ? error.message : '서버 오류가 발생했습니다.';
     return NextResponse.json({ error: errorMessage }, { status: 500 });
+  }
+}
+
+// 교사 인증 요청 삭제
+export async function DELETE(request: NextRequest) {
+  try {
+    const { id } = await request.json();
+
+    const teacherAuthRepository = new PrAdmTchrAuthRepository(prisma);
+    const deleteTeacherAuthUseCase = new DeleteTeacherAuthUseCase(teacherAuthRepository);
+
+    const deletedAuth = await deleteTeacherAuthUseCase.execute(id);
+
+    return NextResponse.json({
+      message: '교사 인증 요청이 성공적으로 삭제되었습니다.',
+      data: { 
+        id: deletedAuth.id, 
+        teacherId: deletedAuth.teacherId 
+      },
+    });
+  } catch (error) {
+    console.error('Teacher auth delete error:', error);
+    const errorMessage =
+      error instanceof Error ? error.message : '서버 오류가 발생했습니다.';
+    return NextResponse.json({ error: errorMessage }, { status: 400 });
   }
 }

--- a/backend/admin/teacher/usecases/CreateTeacherAuthUseCase.ts
+++ b/backend/admin/teacher/usecases/CreateTeacherAuthUseCase.ts
@@ -1,5 +1,5 @@
 import { TeacherAuthorization } from '@/backend/common/domains/entities/TeacherAuthorization';
-import { IAdmTchrAuthCreateRepository } from '@/backend/common/domains/repositories/IAdmTchrAuthCreateRepository';
+import { IAdmTchrAuthCreateRepository } from '@/backend/common/domains/repositories/IAdmTchrAuthRepository';
 
 // 교사 인증 요청 생성 유스케이스
 export class CreateTeacherAuthUseCase {

--- a/backend/admin/teacher/usecases/CreateTeacherAuthUseCase.ts
+++ b/backend/admin/teacher/usecases/CreateTeacherAuthUseCase.ts
@@ -1,11 +1,11 @@
 import { TeacherAuthorization } from '@/backend/common/domains/entities/TeacherAuthorization';
-import { IAdmTchrAuthCreateRepository } from '@/backend/common/domains/repositories/IAdmTchrAuthRepository';
+import { IAdmTchrAuthRepository } from '@/backend/common/domains/repositories/IAdmTchrAuthRepository';
 
 // 교사 인증 요청 생성 유스케이스
 export class CreateTeacherAuthUseCase {
-  private teacherAuthRepository: IAdmTchrAuthCreateRepository;
+  private teacherAuthRepository: IAdmTchrAuthRepository;
 
-  constructor(teacherAuthRepository: IAdmTchrAuthCreateRepository) {
+  constructor(teacherAuthRepository: IAdmTchrAuthRepository) {
     this.teacherAuthRepository = teacherAuthRepository;
   }
 

--- a/backend/admin/teacher/usecases/DeleteTeacherAuthUseCase.ts
+++ b/backend/admin/teacher/usecases/DeleteTeacherAuthUseCase.ts
@@ -1,0 +1,29 @@
+import { TeacherAuthorization } from '@/backend/common/domains/entities/TeacherAuthorization';
+import { IAdmTchrAuthRepository } from '@/backend/common/domains/repositories/IAdmTchrAuthRepository';
+
+// 교사 인증 요청 삭제 유스케이스
+export class DeleteTeacherAuthUseCase {
+  private teacherAuthRepository: IAdmTchrAuthRepository;
+
+  constructor(teacherAuthRepository: IAdmTchrAuthRepository) {
+    this.teacherAuthRepository = teacherAuthRepository;
+  }
+
+  async execute(id: number): Promise<TeacherAuthorization> {
+    if (!id) {
+      throw new Error('삭제할 교사 인증 요청의 ID가 필요합니다.');
+    }
+
+    try {
+      return await this.teacherAuthRepository.delete(id);
+    } catch (error) {
+      console.error('교사 인증 요청 삭제 실패:', error);
+      
+      if (error instanceof Error) {
+        throw error; 
+      }
+      
+      throw new Error('교사 인증 요청 삭제 중 오류가 발생했습니다.');
+    }
+  }
+}

--- a/backend/admin/teacher/usecases/DeleteTeacherAuthUseCase.ts
+++ b/backend/admin/teacher/usecases/DeleteTeacherAuthUseCase.ts
@@ -18,11 +18,11 @@ export class DeleteTeacherAuthUseCase {
       return await this.teacherAuthRepository.delete(id);
     } catch (error) {
       console.error('교사 인증 요청 삭제 실패:', error);
-      
+
       if (error instanceof Error) {
-        throw error; 
+        throw error;
       }
-      
+
       throw new Error('교사 인증 요청 삭제 중 오류가 발생했습니다.');
     }
   }

--- a/backend/admin/teacher/usecases/SelectTeacherAuthListUseCase.ts
+++ b/backend/admin/teacher/usecases/SelectTeacherAuthListUseCase.ts
@@ -1,10 +1,10 @@
 import { TeacherAuthorization } from '@/backend/common/domains/entities/TeacherAuthorization';
-import { IAdmTchrAuthCreateRepository } from '@/backend/common/domains/repositories/IAdmTchrAuthRepository';
+import { IAdmTchrAuthRepository } from '@/backend/common/domains/repositories/IAdmTchrAuthRepository';
 
 export class SelectTeacherAuthListUseCase {
-  private teacherAuthRepository: IAdmTchrAuthCreateRepository;
+  private teacherAuthRepository: IAdmTchrAuthRepository;
 
-  constructor(teacherAuthRepository: IAdmTchrAuthCreateRepository) {
+  constructor(teacherAuthRepository: IAdmTchrAuthRepository) {
     this.teacherAuthRepository = teacherAuthRepository;
   }
 

--- a/backend/admin/teacher/usecases/SelectTeacherAuthListUseCase.ts
+++ b/backend/admin/teacher/usecases/SelectTeacherAuthListUseCase.ts
@@ -1,5 +1,5 @@
 import { TeacherAuthorization } from '@/backend/common/domains/entities/TeacherAuthorization';
-import { IAdmTchrAuthCreateRepository } from '@/backend/common/domains/repositories/IAdmTchrAuthCreateRepository';
+import { IAdmTchrAuthCreateRepository } from '@/backend/common/domains/repositories/IAdmTchrAuthRepository';
 
 export class SelectTeacherAuthListUseCase {
   private teacherAuthRepository: IAdmTchrAuthCreateRepository;
@@ -8,7 +8,10 @@ export class SelectTeacherAuthListUseCase {
     this.teacherAuthRepository = teacherAuthRepository;
   }
 
-  async getAllTeacherAuths(): Promise<{ teacherAuths: TeacherAuthorization[]; total: number }> {
+  async getAllTeacherAuths(): Promise<{
+    teacherAuths: TeacherAuthorization[];
+    total: number;
+  }> {
     try {
       const teacherAuths = await this.teacherAuthRepository.findAll();
 

--- a/backend/common/domains/repositories/IAdmTchrAuthRepository.ts
+++ b/backend/common/domains/repositories/IAdmTchrAuthRepository.ts
@@ -1,6 +1,6 @@
 import { TeacherAuthorization } from '../entities/TeacherAuthorization';
 
-export interface IAdmTchrAuthCreateRepository {
+export interface IAdmTchrAuthRepository {
   create(teacherId: string, imgUrl: string): Promise<TeacherAuthorization>;
   findAll(): Promise<TeacherAuthorization[]>;
 }

--- a/backend/common/domains/repositories/IAdmTchrAuthRepository.ts
+++ b/backend/common/domains/repositories/IAdmTchrAuthRepository.ts
@@ -3,4 +3,5 @@ import { TeacherAuthorization } from '../entities/TeacherAuthorization';
 export interface IAdmTchrAuthRepository {
   create(teacherId: string, imgUrl: string): Promise<TeacherAuthorization>;
   findAll(): Promise<TeacherAuthorization[]>;
+  delete(id: number): Promise<TeacherAuthorization>;
 }

--- a/backend/common/infrastructures/repositories/PrAdmTchrAuthRepository.ts
+++ b/backend/common/infrastructures/repositories/PrAdmTchrAuthRepository.ts
@@ -80,4 +80,23 @@ export class PrAdmTchrAuthRepository implements IAdmTchrAuthRepository {
       throw new Error('교사 인증 요청 목록을 조회하는 중 오류가 발생했습니다.');
     }
   }
+
+  async delete(id: number): Promise<TeacherAuthorization> {
+    try {
+      const deletedAuth = await this.prisma.teacherAuthorization.delete({
+        where: { id },
+      });
+
+      return this.mapToEntity(deletedAuth);
+    } catch (error) {
+      console.error('교사 인증 요청 삭제 실패', { id, error });
+      
+      // Prisma 에러를 사용자 친화적 메시지로 변환
+      if (error instanceof Error && error.message.includes('Record to delete does not exist')) {
+        throw new Error('존재하지 않는 교사 인증 요청입니다.');
+      }
+      
+      throw new Error('교사 인증 요청을 삭제하는 중 오류가 발생했습니다.');
+    }
+  }
 }

--- a/backend/common/infrastructures/repositories/PrAdmTchrAuthRepository.ts
+++ b/backend/common/infrastructures/repositories/PrAdmTchrAuthRepository.ts
@@ -1,10 +1,8 @@
 import { PrismaClient } from '@prisma/client';
 import { TeacherAuthorization } from '@/backend/common/domains/entities/TeacherAuthorization';
-import { IAdmTchrAuthCreateRepository } from '@/backend/common/domains/repositories/IAdmTchrAuthCreateRepository';
+import { IAdmTchrAuthRepository } from '@/backend/common/domains/repositories/IAdmTchrAuthRepository';
 
-export class PrAdmTchrAuthCreateRepository
-  implements IAdmTchrAuthCreateRepository
-{
+export class PrAdmTchrAuthRepository implements IAdmTchrAuthRepository {
   private prisma: PrismaClient;
 
   constructor(prisma: PrismaClient) {
@@ -76,11 +74,10 @@ export class PrAdmTchrAuthCreateRepository
         },
       });
 
-      return teacherAuths.map(auth => this.mapToEntity(auth));
+      return teacherAuths.map((auth) => this.mapToEntity(auth));
     } catch (error) {
       console.error('교사 인증 요청 목록 조회 실패', error);
       throw new Error('교사 인증 요청 목록을 조회하는 중 오류가 발생했습니다.');
     }
   }
-
 }

--- a/backend/common/infrastructures/repositories/PrAdmTchrAuthRepository.ts
+++ b/backend/common/infrastructures/repositories/PrAdmTchrAuthRepository.ts
@@ -90,12 +90,15 @@ export class PrAdmTchrAuthRepository implements IAdmTchrAuthRepository {
       return this.mapToEntity(deletedAuth);
     } catch (error) {
       console.error('교사 인증 요청 삭제 실패', { id, error });
-      
+
       // Prisma 에러를 사용자 친화적 메시지로 변환
-      if (error instanceof Error && error.message.includes('Record to delete does not exist')) {
+      if (
+        error instanceof Error &&
+        error.message.includes('Record to delete does not exist')
+      ) {
         throw new Error('존재하지 않는 교사 인증 요청입니다.');
       }
-      
+
       throw new Error('교사 인증 요청을 삭제하는 중 오류가 발생했습니다.');
     }
   }


### PR DESCRIPTION
## 🔥 PR 제목

선생님 등록 삭제 API 구현

## ✨ 작업 내용

사용자 선생님 등록 시 관리자가 삭제를 할 수 있는 API 구현

## ✅ 체크리스트

- [ ] 코드가 정상적으로 동작하는지 확인했습니다.
- [ ] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [ ] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [ ] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.

## 🚀 테스트 방법
npm run dev

PostMan에 HTTP DELETE 설정 후 http://localhost:3000/api/admin/teacher URL 입력

body = {
  "id": {id}
}

## 📸 스크린샷 / 시연 (선택)

<img width="1333" height="547" alt="image" src="https://github.com/user-attachments/assets/26902f9e-e2d7-41bc-8cfe-f4dc8487aa9d" />

## 🙏 리뷰어에게 한마디

> 코드 리뷰 시 참고할 점, 요청 사항 또는 감사 인사 등을 자유롭게 작성
