### PR TITLE
선생님 등록 승인 api 구현

### DIFF
--- a/backend/admin/teacher/usecases/ApproveTeacherAuthUseCase.ts
+++ b/backend/admin/teacher/usecases/ApproveTeacherAuthUseCase.ts
@@ -1,0 +1,40 @@
+import { TeacherAuthorization } from '@/backend/common/domains/entities/TeacherAuthorization';
+import { IAdmTchrAuthRepository } from '@/backend/common/domains/repositories/IAdmTchrAuthRepository';
+
+// 교사 인증 요청 승인 유스케이스
+export class ApproveTeacherAuthUseCase {
+  private teacherAuthRepository: IAdmTchrAuthRepository;
+
+  constructor(teacherAuthRepository: IAdmTchrAuthRepository) {
+    this.teacherAuthRepository = teacherAuthRepository;
+  }
+
+  async execute(id: number): Promise<TeacherAuthorization> {
+    if (!id) {
+      throw new Error('승인할 교사 인증 요청의 ID가 필요합니다.');
+    }
+
+    try {
+      const teacherAuth = await this.teacherAuthRepository.findById(id);
+      if (!teacherAuth) {
+        throw new Error('존재하지 않는 교사 인증 요청입니다.');
+      }
+
+      await this.teacherAuthRepository.updateUserRole(
+        teacherAuth.teacherId,
+        'teacher'
+      );
+      const deletedAuth = await this.teacherAuthRepository.delete(id);
+
+      return deletedAuth;
+    } catch (error) {
+      console.error('교사 인증 승인 실패:', error);
+
+      if (error instanceof Error) {
+        throw error;
+      }
+
+      throw new Error('교사 인증 승인 중 오류가 발생했습니다.');
+    }
+  }
+}

--- a/backend/common/domains/repositories/IAdmTchrAuthRepository.ts
+++ b/backend/common/domains/repositories/IAdmTchrAuthRepository.ts
@@ -4,4 +4,6 @@ export interface IAdmTchrAuthRepository {
   create(teacherId: string, imgUrl: string): Promise<TeacherAuthorization>;
   findAll(): Promise<TeacherAuthorization[]>;
   delete(id: number): Promise<TeacherAuthorization>;
+  findById(id: number): Promise<TeacherAuthorization | null>;
+  updateUserRole(userId: string, role: string): Promise<void>;
 }

--- a/backend/common/infrastructures/repositories/PrAdmTchrAuthRepository.ts
+++ b/backend/common/infrastructures/repositories/PrAdmTchrAuthRepository.ts
@@ -91,7 +91,6 @@ export class PrAdmTchrAuthRepository implements IAdmTchrAuthRepository {
     } catch (error) {
       console.error('교사 인증 요청 삭제 실패', { id, error });
 
-      // Prisma 에러를 사용자 친화적 메시지로 변환
       if (
         error instanceof Error &&
         error.message.includes('Record to delete does not exist')
@@ -100,6 +99,32 @@ export class PrAdmTchrAuthRepository implements IAdmTchrAuthRepository {
       }
 
       throw new Error('교사 인증 요청을 삭제하는 중 오류가 발생했습니다.');
+    }
+  }
+
+  // 선생님 권한 인증
+  async updateUserRole(userId: string, role: string): Promise<void> {
+    try {
+      await this.prisma.user.update({
+        where: { id: userId },
+        data: { role },
+      });
+    } catch (error) {
+      console.error('사용자 role 업데이트 실패', { userId, role, error });
+      throw new Error('사용자 권한 변경 중 오류가 발생했습니다.');
+    }
+  }
+
+  async findById(id: number): Promise<TeacherAuthorization | null> {
+    try {
+      const teacherAuth = await this.prisma.teacherAuthorization.findUnique({
+        where: { id },
+      });
+
+      return teacherAuth ? this.mapToEntity(teacherAuth) : null;
+    } catch (error) {
+      console.error('교사 인증 요청 조회 실패', { id, error });
+      throw new Error('교사 인증 요청을 조회하는 중 오류가 발생했습니다.');
     }
   }
 }


### PR DESCRIPTION
## 🔥 PR 제목
선생님 등록 승인 api 구현

## ✨ 작업 내용

- 선생님 등록 승인 api 구현

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.

## 🚀 테스트 방법
npm run dev

PostMan HTTP 통신 PATCH로 설정 후 http://localhost:3000/api/admin/teacher URL 입력
body =
{
  "id": {id}
}


## 📸 스크린샷 / 시연 (선택)
**user 테이블에 role = student 사용자로 식별**
<img width="857" height="25" alt="image" src="https://github.com/user-attachments/assets/09f0a6e4-c549-4284-856b-d643b003fb34" />

<br>

**승인**
<img width="1321" height="573" alt="image" src="https://github.com/user-attachments/assets/e7c56163-e802-44d9-af28-9993ff739c8b" />

<br>

**user 테이블에 role = teacher 사용자로 식별 변경 된 걸 확인 할 수 있음**
<img width="761" height="23" alt="image" src="https://github.com/user-attachments/assets/ad660a7c-1c5a-4244-9b75-1a5c4f9b50b0" />


## 🙏 리뷰어에게 한마디

> 코드 리뷰 시 참고할 점, 요청 사항 또는 감사 인사 등을 자유롭게 작성
