### PR TITLE
UnitCard 컴포넌트 텍스트 길이 조정

### DIFF
--- a/app/admin/unit/components/UnitCard.tsx
+++ b/app/admin/unit/components/UnitCard.tsx
@@ -8,13 +8,23 @@ interface UnitCardProps {
   onDelete?: (unit: UnitDto) => void;
 }
 
+const getFontSize = (textLength: number) => {
+  if (textLength <= 5) return 'text-xl md:text-base sm:text-2xl';
+  if (textLength <= 7) return 'text-lg sm:text-xl';
+  if (textLength <= 10) return 'text-base sm:text-lg';
+  if (textLength <= 15) return 'text-sm md:text-xs sm:text-base';
+  return 'text-xs sm:text-sm';
+};
+
 export default function UnitCard({ unit, onEdit, onDelete }: UnitCardProps) {
   return (
     <div className="h-[140px] w-full rounded-2xl border border-purple-100 bg-white/70 backdrop-blur-sm transition-all duration-300 hover:-translate-y-2 hover:shadow-xl hover:shadow-purple-100/50 sm:h-[150px] md:h-[160px]">
       <div className="h-full p-4 sm:p-5 md:p-6">
         <div className="flex h-full flex-col justify-between">
           <div className="flex min-w-0 flex-1 items-center justify-center">
-            <h3 className="w-full truncate px-1 text-center text-xl font-black text-gray-900 sm:text-2xl">
+            <h3
+              className={`w-full px-1 text-center font-black text-gray-900 ${getFontSize(unit.name.length)}`}
+            >
               {unit.name}
             </h3>
           </div>

--- a/app/admin/unit/page.tsx
+++ b/app/admin/unit/page.tsx
@@ -103,7 +103,7 @@ export default function UnitManagementPage() {
     <div className="min-h-screen w-full bg-[#F8F5FF]">
       <div className="w-full px-4 py-8 sm:px-6 lg:mx-auto lg:max-w-[970px] lg:px-8 lg:py-16">
         <div className="mb-8 flex flex-col items-center sm:flex-row sm:justify-between">
-          <h1 className="text-4xl font-semibold tracking-tight text-neutral-500">
+          <h1 className="sm: mb-4 text-4xl font-semibold tracking-tight text-neutral-500">
             과목 관리
           </h1>
           <button


### PR DESCRIPTION
## 🔥 PR 제목

> UnitCard 컴포넌트 텍스트 길이 조정

## ✨ 작업 내용

- UnitCard 컴포넌트 텍스트 길이 조정
- 데스트탑
- 테블릿
- 모바일

## ✅ 체크리스트

- [ ] 코드가 정상적으로 동작하는지 확인했습니다.
- [ ] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [ ] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [ ] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.

## 🚀 테스트 방법

> npm run dev

http://localhost:3000/admin/unit 접속 개발자 도구로 반응형 테스트 진행

## 📸 스크린샷 / 시연 (선택)

데스크탑
<img width="1899" height="915" alt="image" src="https://github.com/user-attachments/assets/d6daa4b2-be37-4653-af92-22d1272cdd7b" />


태블릿
<img width="1008" height="757" alt="image" src="https://github.com/user-attachments/assets/3a67eb4b-1c7e-42de-9a4b-469542cb23c4" />


모바일
<img width="411" height="844" alt="image" src="https://github.com/user-attachments/assets/43e245cd-44ef-4fab-8d84-7b2d7242bf31" />

## 🙏 리뷰어에게 한마디

> 코드 리뷰 시 참고할 점, 요청 사항 또는 감사 인사 등을 자유롭게 작성
