### PR TITLE
feat: 로그인 UI 변경, 토스트 적용, 로그인 엔터로 submit 적용

### DIFF
--- a/app/_components/auth/SignInForm.tsx
+++ b/app/_components/auth/SignInForm.tsx
@@ -3,16 +3,17 @@
 import { signIn } from 'next-auth/react';
 import { useState } from 'react';
 import { signInSchema, type SignInFormData } from '@/libs/zod/auth';
+import { useRouter } from 'next/navigation';
+import { toast } from 'react-toastify';
 
 export default function SignInForm() {
+  const router = useRouter();
   const [errors, setErrors] = useState<Partial<SignInFormData>>({});
   const [isLoading, setIsLoading] = useState(false);
-  const [authError, setAuthError] = useState<string>('');
 
   const handleSubmit = async (formData: FormData) => {
     setIsLoading(true);
     setErrors({});
-    setAuthError('');
 
     try {
       const data = {
@@ -37,17 +38,25 @@ export default function SignInForm() {
         id: data.id,
         password: data.password,
         redirect: false,
-        callbackUrl: '/',
       });
 
       if (signInResult?.error) {
-        setAuthError('아이디 또는 비밀번호가 올바르지 않습니다.');
+        const getErrorMessage = (error: string) => {
+          switch (error) {
+            case 'CredentialsSignin':
+              return '아이디 또는 비밀번호가 올바르지 않습니다.';
+            case 'Configuration':
+              return '시스템 오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
+            default:
+              return '로그인 중 오류가 발생했습니다. 다시 시도해주세요.';
+          }
+        };
+        toast.error(getErrorMessage(signInResult.error));
       } else if (signInResult?.ok) {
-        window.location.href = '/';
+        router.push('/');
       }
     } catch (error) {
       console.error('Sign in error:', error);
-      setAuthError('로그인 중 오류가 발생했습니다. 다시 시도해주세요.');
     } finally {
       setIsLoading(false);
     }
@@ -107,12 +116,6 @@ export default function SignInForm() {
             )}
           </div>
         </div>
-
-        {authError && (
-          <div className="rounded-lg bg-red-50 p-4">
-            <p className="text-sm text-red-600">{authError}</p>
-          </div>
-        )}
 
         <div>
           <button

--- a/app/_components/auth/SignInForm.tsx
+++ b/app/_components/auth/SignInForm.tsx
@@ -11,6 +11,17 @@ export default function SignInForm() {
   const [errors, setErrors] = useState<Partial<SignInFormData>>({});
   const [isLoading, setIsLoading] = useState(false);
 
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !isLoading) {
+      e.preventDefault();
+      const form = e.currentTarget.closest('form');
+      if (form) {
+        const formData = new FormData(form);
+        handleSubmit(formData);
+      }
+    }
+  };
+
   const handleSubmit = async (formData: FormData) => {
     setIsLoading(true);
     setErrors({});
@@ -64,7 +75,11 @@ export default function SignInForm() {
 
   return (
     <div className="w-full max-w-md">
-      <form action={handleSubmit} className="space-y-6">
+      <form
+        onKeyDown={handleKeyDown}
+        action={handleSubmit}
+        className="space-y-6"
+      >
         <div>
           <label
             htmlFor="id"

--- a/app/signin/page.tsx
+++ b/app/signin/page.tsx
@@ -1,34 +1,8 @@
 import SignInForm from '@/app/_components/auth/SignInForm';
 
-function SignInError({ error }: { error?: string }) {
-  if (!error) return null;
-
-  const getErrorMessage = (error: string) => {
-    switch (error) {
-      case 'CredentialsSignin':
-        return '아이디 또는 비밀번호가 올바르지 않습니다.';
-      case 'Configuration':
-        return '시스템 오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
-      default:
-        return '로그인 중 오류가 발생했습니다. 다시 시도해주세요.';
-    }
-  };
-
+export default function SignInPage() {
   return (
-    <div className="mb-6 rounded-lg border border-red-200 bg-red-50 p-4">
-      <div className="text-sm text-red-600">{getErrorMessage(error)}</div>
-    </div>
-  );
-}
-
-export default async function SignInPage({
-  searchParams,
-}: {
-  searchParams: Promise<{ error?: string }>;
-}) {
-  const { error } = await searchParams;
-  return (
-    <div className="mx-auto flex">
+    <div className="flex w-full justify-center">
       <div className="flex min-h-[calc(100vh-3rem)] flex-col justify-center px-6 py-12 lg:px-8">
         <div className="sm:mx-auto sm:w-full sm:max-w-sm">
           <div className="mb-8 text-center">
@@ -43,8 +17,6 @@ export default async function SignInPage({
 
         <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-sm">
           <div className="rounded-2xl bg-white/90 px-6 py-8 shadow-lg outline-1 outline-offset-[-1px] outline-zinc-300 backdrop-blur-[2px]">
-            <SignInError error={error} />
-
             <SignInForm />
           </div>
         </div>


### PR DESCRIPTION
## 🔥 PR 제목

feat: 로그인 UI 변경, 토스트 적용, 로그인 엔터로 submit 적용

## ✨ 작업 내용

- 로그인 페이지 UI 가운데 정렬로 변경
- 로그인 에러 (로그인 실패, 아이디/비밀번호 일치 안함 등)시 토스트로 표시
- 로그인 form에 focus 안 하더라도 (button type="submit"으로 엔터로 submit은 이미 적용됨) 엔터로 submit 가능하게 변경

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.

## 🚀 테스트 방법

- /signup 접속
- 아무 아이디 비밀번호나 누르고 엔터 눌러보기
- 토스트 확인해보기

## 📸 스크린샷 / 시연 (선택)

<img width="645" height="835" alt="image" src="https://github.com/user-attachments/assets/2491a5bc-b79a-4826-bcf9-2f9b47b01fd8" />


## 🙏 리뷰어에게 한마디

감사합니다

Closes #199 