### PR TITLE
선생님 승인 거절 시 게정 삭제

### DIFF
--- a/backend/common/domains/repositories/IAdmTchrAuthRepository.ts
+++ b/backend/common/domains/repositories/IAdmTchrAuthRepository.ts
@@ -11,4 +11,6 @@ export interface IAdmTchrAuthRepository {
   findById(id: number): Promise<TeacherAuthorization | null>;
   findByTeacherId(teacherId: string): Promise<TeacherAuthorization | null>;
   updateUserRole(userId: string, role: string): Promise<void>;
+  deleteUser(teacherId: string): Promise<void>;
+  getUserRole(teacherId: string): Promise<string | null>;
 }

--- a/backend/common/infrastructures/repositories/PrAdmTchrAuthRepository.ts
+++ b/backend/common/infrastructures/repositories/PrAdmTchrAuthRepository.ts
@@ -141,4 +141,28 @@ export class PrAdmTchrAuthRepository implements IAdmTchrAuthRepository {
 
     return teacherAuth ? this.mapToEntity(teacherAuth) : null;
   }
+
+  async deleteUser(teacherId: string): Promise<void> {
+    try {
+      await this.prisma.user.delete({
+        where: { id: teacherId },
+      });
+    } catch (error) {
+      console.error('사용자 계정 삭제 실패:', { teacherId, error });
+      throw new Error('사용자 계정 삭제 중 오류가 발생했습니다.');
+    }
+  }
+
+  async getUserRole(teacherId: string): Promise<string | null> {
+    try {
+      const user = await this.prisma.user.findUnique({
+        where: { id: teacherId },
+        select: { role: true },
+      });
+      return user?.role || null;
+    } catch (error) {
+      console.error('사용자 role 조회 실패:', { teacherId, error });
+      throw new Error('사용자 정보 조회 중 오류가 발생했습니다.');
+    }
+  }
 }


### PR DESCRIPTION
## 🔥 PR 제목

> 선생님 승인 거절 시 게정 삭제

## ✨ 작업 내용

- 선생님 승인 거절 된 사용자 계정 삭제

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.

## 🚀 테스트 방법

> npm run dev

http://localhost:3000/signin

선생님 회원가입 후

관리자 계정 = ID : ADMIN, Password :  test-password

선생님 승인 페이지에서 승인 거절 버튼 클릭

## 📸 스크린샷 / 시연 (선택)

![승인 거절](https://github.com/user-attachments/assets/e22cf3a1-c0e7-494d-be11-4165a233e49b)


## 🙏 리뷰어에게 한마디

> 수고가 많으십니다 
#206 
