### PR TITLE
fix: 오답노트 HelpModal 깜빡임 및 가상키보드 포커스 유지 문제 해결

### DIFF
--- a/app/_components/molecules/AnswerSection.tsx
+++ b/app/_components/molecules/AnswerSection.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { createPortal } from 'react-dom';
 import { ButtonVariant } from '../atoms/Button';
 import HelpModal from './HelpModal';
 import MathInput from './MathInput';
@@ -95,11 +96,16 @@ export default function AnswerSection({
 
   return (
     <>
-      {/* Help Modal */}
-      <HelpModal
-        isOpen={isHelpModalOpen}
-        onClose={() => setIsHelpModalOpen(false)}
-      />
+      {/* Help Modal - Rendered via portal to avoid positioning issues */}
+      {typeof window !== 'undefined' &&
+        isHelpModalOpen &&
+        createPortal(
+          <HelpModal
+            isOpen={isHelpModalOpen}
+            onClose={() => setIsHelpModalOpen(false)}
+          />,
+          document.body
+        )}
 
       <div className="mx-auto w-full">
         <div className="space-y-4">


### PR DESCRIPTION
## 🔥 PR 제목

fix: 오답노트 HelpModal 깜빡임 및 가상키보드 포커스 유지 문제 해결

## ✨ 작업 내용

### 1. HelpModal 깜빡임 문제 해결
- HelpModal이 ErrorNoteCard 내부 DOM 계층에서 렌더링되면서 발생하는 positioning 충돌 해결
- `createPortal`을 사용하여 HelpModal을 `document.body`에 직접 렌더링하도록 변경
- 카드의 transform/positioning 영향을 받지 않도록 DOM 계층에서 완전히 분리

### 2. 가상키보드 간격 클릭 시 포커스 유지 문제 해결  
- 카드나 가상키보드의 빈 공간 클릭 시 `activeElement`가 `<body>`로 변경되어 포커스 감지 실패하는 문제 해결
- 실제 클릭 위치를 추적하는 `lastClickTargetRef` 구현
- 포커스 감지 로직을 이중화하여 `activeElement`와 `clickTarget` 모두 확인
- 포커스된 카드(`[data-problem-card]`) 또는 가상키보드(`[data-virtual-keyboard]`) 내부 클릭 시 포커스 유지

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.

## 🚀 테스트 방법

### HelpModal 깜빡임 테스트:
1. 오답노트 페이지에서 문제 카드의 답안 입력 영역 클릭
2. 도움말(?) 버튼 클릭
3. HelpModal이 안정적으로 렌더링되는지 확인 (깜빡임 없음)
4. 모달 외부 클릭 시 정상적으로 닫히는지 확인

### 가상키보드 포커스 유지 테스트:
1. 오답노트 페이지에서 답안 입력 영역 클릭하여 가상키보드 활성화
2. 카드의 빈 공간(padding, margin 영역) 클릭
3. 가상키보드가 유지되고 입력 포커스가 그대로인지 확인
4. 가상키보드의 키 사이 빈 공간 클릭
5. 가상키보드가 유지되고 입력 포커스가 그대로인지 확인
6. 카드 완전 외부 클릭 시 정상적으로 포커스 해제되는지 확인

### 빌드 및 린트 테스트:
- `npm run lint`: ✅ 통과
- `npm run build`: ✅ 통과

## 🙏 리뷰어에게 한마디

이 PR은 UX 개선을 위한 중요한 수정입니다. 특히 가상키보드 포커스 유지 문제는 사용자가 실수로 빈 공간을 클릭했을 때 입력이 중단되는 불편함을 해결합니다. 

핵심 아이디어는 `activeElement` (포커스가 어디에 있는지)뿐만 아니라 실제 클릭한 위치(`clickTarget`)도 함께 추적하여 더 정확한 의도 파악을 하는 것입니다.

Closes #215