### PR TITLE
Style: 수식 자판의 변수 버튼 더 변수 표시처럼 바꾸기

### DIFF
--- a/app/_components/molecules/NumberPad.tsx
+++ b/app/_components/molecules/NumberPad.tsx
@@ -51,7 +51,7 @@ export default function NumberPad({
 }: NumberPadProps) {
   const numbers = ['1', '2', '3', '4', '5', '6', '7', '8', '9'];
   const advancedOperators = ['√', '^', '(', ')'];
-  const variables = ['x', 'y', 'π'];
+  const variables = ['𝑥', 'y', 'π'];
 
   return (
     <div className="mx-auto w-full">

--- a/app/_components/molecules/NumberPad.tsx
+++ b/app/_components/molecules/NumberPad.tsx
@@ -51,7 +51,7 @@ export default function NumberPad({
 }: NumberPadProps) {
   const numbers = ['1', '2', '3', '4', '5', '6', '7', '8', '9'];
   const advancedOperators = ['√', '^', '(', ')'];
-  const variables = ['𝑥', 'y', 'π'];
+  const variables = ['𝑥', '𝑦', 'π'];
 
   return (
     <div className="mx-auto w-full">

--- a/app/error-note/_components/VirtualKeyboard.tsx
+++ b/app/error-note/_components/VirtualKeyboard.tsx
@@ -53,7 +53,7 @@ export default function VirtualKeyboard({
 }: VirtualKeyboardProps) {
   const numbers = ['1', '2', '3', '4', '5', '6', '7', '8', '9'];
   const advancedOperators = ['√', '^', '(', ')'];
-  const variables = ['x', 'y', 'π'];
+  const variables = ['𝑥', 'y', 'π'];
 
   return (
     <div

--- a/app/error-note/_components/VirtualKeyboard.tsx
+++ b/app/error-note/_components/VirtualKeyboard.tsx
@@ -53,7 +53,7 @@ export default function VirtualKeyboard({
 }: VirtualKeyboardProps) {
   const numbers = ['1', '2', '3', '4', '5', '6', '7', '8', '9'];
   const advancedOperators = ['√', '^', '(', ')'];
-  const variables = ['𝑥', 'y', 'π'];
+  const variables = ['𝑥', '𝑦', 'π'];
 
   return (
     <div


### PR DESCRIPTION
## 🔥 PR 제목

Style: 수식 자판의 변수 버튼 더 변수 표시처럼 바꾸기

## ✨ 작업 내용

- xy를 수학 변수 유니코드로 변경

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.

## 🚀 테스트 방법

- 로그인 하기
- 연습문제 들어가보기
- 연습문제 자판 확인해보기

## 📸 스크린샷 / 시연 (선택)

<img width="1462" height="669" alt="image" src="https://github.com/user-attachments/assets/c61060b1-bc51-4595-88dc-87251d35663f" />


## 🙏 리뷰어에게 한마디

감사합니다

Closes #221 