### PR TITLE
style: 전체 레이아웃 변경에 따른 페이지 레이아웃 조정

### DIFF
--- a/app/_components/cards/TestCard.tsx
+++ b/app/_components/cards/TestCard.tsx
@@ -36,7 +36,7 @@ export default function TestCard({ solves, category }: TestCardProps) {
     : '';
 
   return (
-    <div className="inline-flex w-96 flex-col items-start justify-start overflow-hidden rounded-2xl bg-white/90 p-4 shadow-lg outline-1 outline-offset-[-1px] outline-zinc-300 backdrop-blur-[2px] desktop:w-[30vw]">
+    <div className="inline-flex w-96 flex-col items-start justify-start overflow-hidden rounded-2xl bg-white/90 p-4 shadow-lg outline-1 outline-offset-[-1px] outline-zinc-300 backdrop-blur-[2px] desktop:w-[28vw]">
       <div className="flex flex-col items-start justify-start self-stretch">
         <div className="inline-flex items-center justify-start self-stretch">
           <div className="justify-end text-lg leading-7 font-bold text-gray-800">

--- a/app/error-note/_components/ErrorNoteInterface.tsx
+++ b/app/error-note/_components/ErrorNoteInterface.tsx
@@ -300,7 +300,7 @@ export default function ErrorNoteInterface() {
   // 렌더
   return (
     <div className="mx-auto w-full">
-      <div className="mx-auto pt-6 tablet:px-32">
+      <div className="mx-auto pt-6 tablet:px-16 desktop:px-24">
         {/* Mobile */}
         <div className="tablet:hidden">
           <div className="mb-6 text-center">

--- a/app/globals.css
+++ b/app/globals.css
@@ -15,9 +15,11 @@ html {
 body {
   background-color: #f8f5ff;
 }
+
 :root {
   --sidebar-w: 120px;
 }
+
 /* Design System Tokens as CSS Variables */
 @theme {
   /* Color Tokens */
@@ -35,6 +37,7 @@ body {
   --color-sidebar-button: #eaddff;
   --color-sidebar-icon: #6750a4;
   --color-card-background: #f2e8fe;
+  
   /* Font Size Tokens - Override Tailwind defaults with 20% increased sizes */
   /* Standard Tailwind font sizes - increased by 20%, rounded appropriately */
   --text-xs: 14px;     /* Override default 12px */

--- a/app/mypage/[id]/error-note/MyPageErrorNote.tsx
+++ b/app/mypage/[id]/error-note/MyPageErrorNote.tsx
@@ -332,7 +332,7 @@ export default function MyPageErrorNote() {
 
   return (
     <div className="mx-auto w-full">
-      <div className="mx-auto pt-6 tablet:px-32">
+      <div className="mx-auto pt-6 tablet:px-16 desktop:px-24">
         {!canEdit && (
           <div className="mx-4 mb-4 rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900 tablet:mx-0">
             이 페이지는 <b>읽기 전용</b>입니다. 내 문제가 아니므로 정답 수정이


### PR DESCRIPTION
## 🔥 PR 제목

> style: 전체 레이아웃 변경에 따른 페이지 레이아웃 조정

## ✨ 작업 내용

- TestCard 컴포넌트의 데스크톱 너비를 30vw에서 28vw로 조정하여 레이아웃 일관성 개선
- ErrorNoteInterface와 MyPageErrorNote 컴포넌트의 패딩을 조정 (태블릿: px-32 → px-16, 데스크톱: px-24 추가)
- globals.css에서 CSS 변수 주석 정리 및 포맷팅 개선

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.

## 🚀 테스트 방법

> 각 페이지에서 태블릿 및 데스크톱 뷰포트에서 레이아웃이 올바르게 표시되는지 확인

## 📸 스크린샷 / 시연 (선택)

> UI 변경 사항: 패딩 및 카드 너비 조정으로 더 나은 레이아웃 일관성 제공

## 🙏 리뷰어에게 한마디

> 전체 레이아웃 변경에 따른 미세한 조정 사항들입니다. 각 컴포넌트의 패딩과 너비가 일관되게 적용되었는지 확인해 주세요.

Closes #273

🤖 Generated with [Claude Code](https://claude.ai/code)