### PR TITLE
style/practice-category UI/UX 수정 및 코드 리팩토링

### DIFF
--- a/app/practice-category/components/SearchInput.tsx
+++ b/app/practice-category/components/SearchInput.tsx
@@ -31,12 +31,12 @@ const SearchInput = ({
       <div className="flex items-center gap-2 rounded-full border border-gray-300 bg-white px-4 py-2">
         <input
           type="text"
-          placeholder={placeholder ?? '카테고리 검색'}
+          placeholder={placeholder ?? '단원 검색'}
           value={value}
           onChange={(e) => onChange(e.target.value)}
           onKeyDown={handleKeyDown}
           className="w-64 bg-transparent text-base outline-none max-[420px]:w-44"
-          aria-label="카테고리 검색"
+          aria-label="단원 검색"
         />
       </div>
       <button

--- a/app/practice-category/components/unitMeta.ts
+++ b/app/practice-category/components/unitMeta.ts
@@ -1,0 +1,57 @@
+/**
+ * 유닛별 카드 보조 정보(배경색, 설명)
+ * - 현재 db에 description이 없어서 임시로 추가하였음.
+ * 차후에 description을 추가하면 이 파일에서 description을 삭제하고 accentClass만 사용하면 됨.
+ */
+export type UnitMeta = Record<
+  string,
+  { accentClass: string; description: string }
+>;
+
+export const UNIT_META: UnitMeta = {
+  // 상단 라인
+  이차방정식: {
+    accentClass: 'bg-gradient-to-br from-rose-50 to-pink-50',
+    description: '이차방정식을 풀어 해를 구해요.',
+  },
+  인수분해: {
+    accentClass: 'bg-gradient-to-br from-sky-50 to-indigo-50',
+    description: '식을 인수로 분해하는 방법을 배워요.',
+  },
+  '다항식의 덧셈과 곱셈': {
+    accentClass: 'bg-gradient-to-br from-emerald-50 to-green-50',
+    description: '다항식의 연산을 마스터해요.',
+  },
+
+  // 중단 라인
+  지수법칙: {
+    accentClass: 'bg-gradient-to-br from-yellow-50 to-amber-50',
+    description: '거듭제곱의 규칙을 이해해요.',
+  },
+  일차방정식: {
+    accentClass: 'bg-gradient-to-br from-violet-50 to-fuchsia-50',
+    description: '방정식을 풀어 미지수를 찾아요.',
+  },
+  '일차식의 곱셈과 나눗셈': {
+    accentClass: 'bg-gradient-to-br from-orange-50 to-amber-50',
+    description: '문자식의 곱셈과 나눗셈을 배워요.',
+  },
+
+  // 하단 라인
+  '일차식의 덧셈과 뺄셈': {
+    accentClass: 'bg-gradient-to-br from-teal-50 to-cyan-50',
+    description: '문자를 사용한 식의 계산을 연습해요.',
+  },
+  '정수와 유리수의 사칙계산': {
+    accentClass: 'bg-gradient-to-br from-sky-50 to-blue-50',
+    description: '음수와 분수의 계산을 마스터해요.',
+  },
+  '정수와유리수의 사칙계산': {
+    accentClass: 'bg-gradient-to-br from-sky-50 to-blue-50',
+    description: '음수와 분수의 계산을 마스터해요.',
+  },
+  소인수분해: {
+    accentClass: 'bg-gradient-to-br from-pink-50 to-rose-50',
+    description: '수를 소인수로 분해하는 방법을 배워요.',
+  },
+};

--- a/app/practice-category/page.tsx
+++ b/app/practice-category/page.tsx
@@ -5,64 +5,9 @@ import CategoryCard from './components/categoryCard';
 import ProgressBar from './components/ProgressBar';
 import SearchInput from './components/SearchInput';
 import { useGets } from '@/hooks/useGets';
+import { UNIT_META } from './components/unitMeta';
 
 type UnitsResponse = { units: { id: number; name: string }[] };
-
-// 유닛별 카드 보조 정보(배경색, 설명)
-const UNIT_META: Record<string, { accentClass: string; description: string }> =
-  {
-    // 상단 라인
-    이차방정식: {
-      accentClass: 'bg-gradient-to-br from-rose-50 to-pink-50',
-      description: '이차방정식을 풀어 해를 구해요.',
-    },
-    인수분해: {
-      accentClass: 'bg-gradient-to-br from-sky-50 to-indigo-50',
-      description: '식을 인수로 분해하는 방법을 배워요.',
-    },
-    '다항식의 덧셈과 곱셈': {
-      accentClass: 'bg-gradient-to-br from-emerald-50 to-green-50',
-      description: '다항식의 연산을 마스터해요.',
-    },
-
-    // 중단 라인
-    지수법칙: {
-      accentClass: 'bg-gradient-to-br from-yellow-50 to-amber-50',
-      description: '거듭제곱의 규칙을 이해해요.',
-    },
-    일차방정식: {
-      accentClass: 'bg-gradient-to-br from-violet-50 to-fuchsia-50',
-      description: '방정식을 풀어 미지수를 찾아요.',
-    },
-    '일차식의 곱셈과 나눗셈': {
-      accentClass: 'bg-gradient-to-br from-orange-50 to-amber-50',
-      description: '문자식의 곱셈과 나눗셈을 배워요.',
-    },
-
-    // 하단 라인
-    '일차식의 덧셈과 뺄셈': {
-      accentClass: 'bg-gradient-to-br from-teal-50 to-cyan-50',
-      description: '문자를 사용한 식의 계산을 연습해요.',
-    },
-    '정수와 유리수의 사칙계산': {
-      accentClass: 'bg-gradient-to-br from-sky-50 to-blue-50',
-      description: '음수와 분수의 계산을 마스터해요.',
-    },
-    '정수와유리수의 사칙계산': {
-      accentClass: 'bg-gradient-to-br from-sky-50 to-blue-50',
-      description: '음수와 분수의 계산을 마스터해요.',
-    },
-    소인수분해: {
-      accentClass: 'bg-gradient-to-br from-pink-50 to-rose-50',
-      description: '수를 소인수로 분해하는 방법을 배워요.',
-    },
-
-    // 기존 항목도 유지 (일부 화면에서 사용될 수 있음)
-    '수와 연산': {
-      accentClass: 'bg-gradient-to-br from-rose-50 to-amber-50',
-      description: '기본적인 수의 개념과 사칙연산을 배워요.',
-    },
-  };
 
 const PracticeCategoryPage = () => {
   const [searchInput, setSearchInput] = useState('');
@@ -135,13 +80,12 @@ const PracticeCategoryPage = () => {
   const handleSubmit = () => setSubmittedQuery(searchInput);
 
   return (
-    <div className="relative flex w-full flex-col p-8">
+    <div className="relative flex w-full flex-col p-12 min-[1181px]:pl-30">
       {/* 상단 히어로: 문제풀기 카드 + 진행률 */}
       <section className="mb-8 rounded-3xl border border-gray-100 bg-gradient-to-r from-indigo-50 via-fuchsia-50 to-rose-50 p-6 shadow-sm">
         <div className="flex items-center justify-between gap-6 max-[680px]:flex-col max-[680px]:items-start">
           <div>
-            <div className="text-3xl font-semibold">문제풀기</div>
-            <div className="mt-2 text-gray-700">
+            <div className="mt-2 text-2xl text-gray-700">
               {/* 출석 완료 시 완료 문구로 변경 */}
               {attendance ? (
                 attendance.remainingCount <= 0 ? (
@@ -158,15 +102,6 @@ const PracticeCategoryPage = () => {
               )}
             </div>
           </div>
-          <div className="text-2xl font-semibold text-indigo-700">
-            {attendance ? (
-              <>
-                {attendance.solvedCount}/{attendance.targetCount} 문제
-              </>
-            ) : (
-              <span className="text-gray-500">0/0 문제</span>
-            )}
-          </div>
         </div>
         <div className="mt-4">
           <ProgressBar progress={attendance ? attendance.progressPercent : 0} />
@@ -176,15 +111,17 @@ const PracticeCategoryPage = () => {
       {/* 학습 카테고리 헤더 */}
       <section className="flex flex-col gap-3">
         <div className="flex items-end justify-between gap-5 max-[680px]:flex-col max-[680px]:items-start">
-          <h2 className="text-2xl font-semibold">학습 카테고리</h2>
-          <SearchInput
-            value={searchInput}
-            onChange={setSearchInput}
-            onSubmit={handleSubmit}
-          />
+          <h2 className="text-2xl font-semibold">학습 단원</h2>
+          <div className="relative min-[681px]:top-5">
+            <SearchInput
+              value={searchInput}
+              onChange={setSearchInput}
+              onSubmit={handleSubmit}
+            />
+          </div>
         </div>
         <p className="text-sm text-gray-500">
-          카테고리를 선택해서 문제를 풀어보세요!
+          학습단원을 선택해서 문제를 풀어보세요!
         </p>
       </section>
 


### PR DESCRIPTION
## 🔥 PR 제목

style/practice-category UI/UX 수정 및 코드 리팩토링

## ✨ 작업 내용

- UI/UX 수정
- 코드 리펙토링

UNIT_META 상수 분리
UNIT_META를 app/practice-category/components/unitMeta.ts로 이동하여 재사용성과 가독성 향상
UnitMeta 타입 정의 추가
페이지에서는 UNIT_META를 import하여 사용
카피 업데이트
헤더 타이틀: “학습 카테고리” → “학습 단원”
보조 문구: “카테고리를 선택해서 문제를 풀어보세요!” → “학습단원을 선택해서 문제를 풀어보세요!”
검색 영역만 하강하도록 UI 조정
섹션 전체 높이를 늘리지 않기 위해 padding 대신 relative top 사용
SearchInput 래퍼에 min-[681px]:top-5 적용
반응형 좌측 패딩 개선
페이지 컨테이너 좌측 패딩을 데스크탑에서만 적용: min-[1181px]:pl-30
모바일/태블릿에서는 좌측 패딩 제거, 전체 레이아웃은 유지
컨테이너 기본 여백 조정
p-12로 기본 여백 통일
불필요 블록 정리
상단 히어로 우측의 진행 텍스트(총 문제 수 표시) 제거로 헤더 단순화

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.

## 🚀 테스트 방법

페이지: practice-category 진입
뷰포트별 확인
680px 이하: 검색 영역 상단 이동 없음, 레이아웃 깨짐 없음
681px 이상 ~ 1180px: 검색 영역이 제목 대비 약간 아래로 보임(top-5), 좌측 패딩 없음
1181px 이상: 검색 영역은 동일하게 아래로 보이고, 컨테이너에 좌측 패딩 pl-30 적용
카드 메타 데이터 확인
주어진 단원명에 맞춰 카드 배경(accentClass)과 설명이 올바르게 적용되는지 확인
리그레션
검색 실행 시 필터 동작 정상
상단 히어로의 진행바 렌더 정상

## 📸 스크린샷 / 시연 (선택)

데스크탑
<img width="1261" height="665" alt="데스크탑" src="https://github.com/user-attachments/assets/961c1abd-396b-4944-8807-77dd5fe379d7" />

모바일
<img width="187" height="341" alt="모바일" src="https://github.com/user-attachments/assets/c2b2f19e-b695-4791-9f6d-f19ed44c4068" />

테블릿
<img width="434" height="409" alt="테블릿" src="https://github.com/user-attachments/assets/8d191819-4abf-4885-afe4-53f8dd3ddb17" />


## 🙏 리뷰어에게 한마디

closes #275 