### PR TITLE
fix: 시험지 보기 안되는 현상 수정

### DIFF
--- a/app/teacher/unit-exam-codes/page.tsx
+++ b/app/teacher/unit-exam-codes/page.tsx
@@ -210,6 +210,10 @@ export default function UnitExamCodesPage() {
                   if (!ok) return;
                   await deleteCode({ path: `/admin/unit-exam-codes/${code}` });
                 }}
+                onOpenProblems={(code: string) => {
+                  setProblemsForCode(code);
+                  setIsProblemsOpen(true);
+                }}
               />
             )}
 


### PR DESCRIPTION
## 🔥 PR 제목

fix: 시험지 보기 안되는 현상 수정

## ✨ 작업 내용

모바일에서 시험지 보기 모달이 열리지 않는 현상을 수정하였습니다.

원인
모바일 경로에서 모달 오픈 콜백 누락: UnitExamCodeTable 내부 버튼은 onOpenProblems?.(item.code)를 호출하는데, app/teacher/unit-exam-codes/page.tsx의 모바일 섹션(lg:hidden)에서 onOpenProblems를 전달하지 않아 클릭해도 아무 동작이 없었습니다. 데스크톱 섹션에는 콜백이 전달되어 정상 동작했습니다.
수정한 부분
파일: app/teacher/unit-exam-codes/page.tsx
내용: 모바일 섹션에서 UnitExamCodeTable 호출 시 onOpenProblems 콜백을 연결했습니다. 모달에 표시할 코드를 상태로 세팅하고, 모달 오픈 상태를 true로 바꿉니다.

## ✅ 체크리스트

- [ ] 코드가 정상적으로 동작하는지 확인했습니다.
- [ ] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [ ] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [ ] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.

## 🚀 테스트 방법

> 직접 테스트한 방법 또는 테스트 코드 내용 (있다면)

## 📸 스크린샷 / 시연 (선택)

> UI 변경 사항이 있다면 스크린샷 또는 GIF를 첨부

## 🙏 리뷰어에게 한마디

> 코드 리뷰 시 참고할 점, 요청 사항 또는 감사 인사 등을 자유롭게 작성
