### PR TITLE
fix: middleware에서 sitemap.xml이 리디렉트 되는 문제 해결

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -15,6 +15,7 @@ const PUBLIC_PREFIXES = [
   '/assets',
   '/signup/teacher/pending',
   '/robots.txt',
+  '/sitemap.xml',
 ];
 
 // 역할별 메인 페이지 매핑


### PR DESCRIPTION
## 🔥 PR 제목

> fix: middleware에서 sitemap.xml이 리디렉트 되는 문제 해결

## ✨ 작업 내용

- Nextjs middleware redirect 제외 리스트에 sitemap.xml 추가

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.

## 🚀 테스트 방법

- `npm run dev` 실행
- http://localhost:3000/sitemap.xml 접속
- sitemap이 표시되는 것을 확인

## 📸 스크린샷 / 시연 (선택)

<img width="1954" height="1208" alt="image" src="https://github.com/user-attachments/assets/34ba97cb-040b-44d5-b553-177fa5ea160c" />


## 🙏 리뷰어에게 한마디

sitemap은 반드시 필요하지는 않지만 검색 엔진에 도움이 되는 요소입니다.
https://medium.com/@sdgwsld/ssemtle-seo-ab42aec5c755

Closes #349 